### PR TITLE
Add Travis CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+node_js:
+  - "7"
+  - "6"
+before_script:
+  - npm run build
+  - npm run latest
+  - npm run seed

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ before_script:
   - npm run build
   - npm run latest
   - npm run seed
+before_deploy:
+  - npm run docs
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN
+  local_dir: docs
+  on:
+    branch: master

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ messages
 
 > Notification message pipeline
 
+[![Build Status][travis-svg]][travis-link]
+
 ## Install
 
 Install dependencies with [Yarn](https://yarnpkg.com/).
@@ -112,3 +114,6 @@ $ npm run seed
 ## License
 
 [MIT](LICENSE).
+
+[travis-svg]: https://travis-ci.org/j-/messages.svg
+[travis-link]: https://travis-ci.org/j-/messages


### PR DESCRIPTION
Runs on node v6 and v7 (the [TypeScript compile target](https://github.com/j-/messages/blob/78c664373cdeb87db0fe370e0e205fdbcb4500be/tsconfig.json#L3) is set to `es6`).

Builds the project and initializes the database before running tests.

Deploys to GitHub pages after a successful build on master.