### PR TITLE
Add HTTP response statuses module

### DIFF
--- a/src/api/http-response.ts
+++ b/src/api/http-response.ts
@@ -1,0 +1,27 @@
+/*
+ * Explanations from MDN.
+ * See https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
+ */
+
+/**
+ * Indicates that the request has succeeded.
+ */
+export const STATUS_OK = 200;
+
+/**
+ * Indicates that the request has succeeded and has led to the creation of a
+ * resource.
+ */
+export const STATUS_CREATED = 201;
+
+/**
+ * Indicates that the server could not understand the request due to invalid
+ * syntax.
+ */
+export const STATUS_BAD_REQUEST = 400;
+
+/**
+ * Indicates that the server encountered an unexpected condition that prevented
+ * it from fulfilling the request.
+ */
+export const STATUS_INTERNAL_SERVER_ERROR = 500;


### PR DESCRIPTION
Start with only a few statuses:

* `200` `OK`
* `201` `CREATED`
* `400` `STATUS_BAD_REQUEST`
* `500` `INTERNAL_SERVER_ERROR`

Since there are no more magic numbers in the 'nodes' API module, we can now remove the `status` and `response` assignments and consume them directly.