### PR TITLE
Enforce an API response format

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "supertest": "^3.0.0",
     "tslint": "^5.1.0",
     "typedoc": "^0.5.10",
-    "typescript": "^2.2.2"
+    "typescript": "^2.3.2"
   },
   "dependencies": {
     "body-parser": "^1.17.1",

--- a/src/api/nodes.ts
+++ b/src/api/nodes.ts
@@ -2,6 +2,7 @@ import * as express from 'express';
 import { json } from 'body-parser';
 import { execute } from '../engine';
 import { parseIds } from './id-utils';
+import { send } from './send';
 
 import {
 	STATUS_OK,
@@ -16,6 +17,14 @@ import {
 	IActionCreateNode,
 } from '../actions';
 
+import {
+	IMessage,
+} from '../message';
+
+import {
+	INode,
+} from '../node';
+
 const app: express.Express = express();
 app.use(json());
 
@@ -26,7 +35,7 @@ app.use('/:ids', (req, res, next) => {
 		};
 		next();
 	} catch (err) {
-		res.status(STATUS_BAD_REQUEST).send({
+		send(res, STATUS_BAD_REQUEST, {
 			error: {
 				name: 'SyntaxError',
 				message: err.message,
@@ -43,24 +52,24 @@ app.get('/:ids/messages', async (req, res) => {
 	try {
 		const messages = await execute(action);
 		if (messages) {
-			res.status(STATUS_OK).send({
+			send<IMessage[]>(res, STATUS_OK, {
 				result: messages,
 			});
 		} else {
-			res.status(STATUS_OK).send({
-				result: new Array(),
+			send<IMessage[]>(res, STATUS_OK, {
+				result: [],
 			});
 		}
 	} catch (err) {
 		if (err.code === 'SQLITE_ERROR') {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'DatabaseError',
 					message: 'Error communicating with database',
 				},
 			});
 		} else {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'UnknownError',
 					message: 'An unknown error occurred',
@@ -75,7 +84,7 @@ app.get('/:ids/messages', async (req, res) => {
 app.post('/:ids/messages', async (req, res) => {
 	const nodeIds: string[] = (<any>req).context.ids;
 	if (nodeIds.length > 1) {
-		res.status(STATUS_BAD_REQUEST).send({
+		send(res, STATUS_BAD_REQUEST, {
 			error: {
 				name: 'InvalidRequestError',
 				message: 'Can only create a message on one node at a time',
@@ -83,7 +92,7 @@ app.post('/:ids/messages', async (req, res) => {
 		});
 		return;
 	} else if (!req.body) {
-		res.status(STATUS_BAD_REQUEST).send({
+		send(res, STATUS_BAD_REQUEST, {
 			error: {
 				name: 'MissingPayloadError',
 				message: 'Request body is required',
@@ -99,31 +108,31 @@ app.post('/:ids/messages', async (req, res) => {
 	try {
 		const message = await execute(action);
 		if (message) {
-			res.status(STATUS_OK).send({
+			send<IMessage>(res, STATUS_OK, {
 				result: message,
 			});
 		} else {
-			res.status(STATUS_OK).send({
-				result: <any>null,
+			send<IMessage>(res, STATUS_OK, {
+				result: null,
 			});
 		}
 	} catch (err) {
 		if (err.name === 'TypeError') {
-			res.status(STATUS_BAD_REQUEST).send({
+			send(res, STATUS_BAD_REQUEST, {
 				error: {
 					name: 'TypeError',
 					message: err.message,
 				},
 			});
 		} else if (err.code === 'SQLITE_ERROR') {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'DatabaseError',
 					message: 'Error communicating with database',
 				},
 			});
 		} else {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'UnknownError',
 					message: 'An unknown error occurred',
@@ -137,7 +146,7 @@ app.post('/:ids/messages', async (req, res) => {
 
 app.post('/', async (req, res) => {
 	if (!req.body) {
-		res.status(STATUS_BAD_REQUEST).send({
+		send(res, STATUS_BAD_REQUEST, {
 			error: {
 				name: 'MissingPayloadError',
 				message: 'Request body is required',
@@ -152,38 +161,38 @@ app.post('/', async (req, res) => {
 	try {
 		const node = await execute(action);
 		if (node) {
-			res.status(STATUS_CREATED).send({
+			send<INode>(res, STATUS_CREATED, {
 				result: node,
 			});
 		} else {
-			res.status(STATUS_OK).send({
-				result: <any>null,
+			send<INode>(res, STATUS_OK, {
+				result: null,
 			});
 		}
 	} catch (err) {
 		if (err.name === 'UnrecognizedNodeTypeError') {
-			res.status(STATUS_BAD_REQUEST).send({
+			send(res, STATUS_BAD_REQUEST, {
 				error: {
 					name: err.name,
 					message: err.message,
 				},
 			});
 		} else if (err.name === 'InvalidPropertyError') {
-			res.status(STATUS_BAD_REQUEST).send({
+			send(res, STATUS_BAD_REQUEST, {
 				error: {
 					name: err.name,
 					message: err.message,
 				},
 			});
 		} else if (err.code === 'SQLITE_ERROR') {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'DatabaseError',
 					message: 'Error communicating with database',
 				},
 			});
 		} else {
-			res.status(STATUS_INTERNAL_SERVER_ERROR).send({
+			send(res, STATUS_INTERNAL_SERVER_ERROR, {
 				error: {
 					name: 'UnknownError',
 					message: 'An unknown error occurred',

--- a/src/api/send.ts
+++ b/src/api/send.ts
@@ -1,0 +1,40 @@
+import { Response } from 'express';
+
+/**
+ * Error responses will conform to this format.
+ */
+export interface IResponseError {
+	error: {
+		/**
+		 * All errors will have a name that identifies the _type_ of error.
+		 */
+		name: string;
+
+		/**
+		 * The message body should describe exactly what the error was.
+		 */
+		message: string;
+	};
+}
+
+/**
+ * Result responses will conform to this format.
+ */
+export interface IResponseResult<T = any> {
+	/**
+	 * Result can be anything.
+	 */
+	result: T;
+}
+
+/**
+ * Send a response to the user in a consistent API structure.
+ *
+ * @param res Express response object
+ * @param status HTTP status code (1xx, 2xx, 3xx, 4xx or 5xx)
+ * @param response Response payload. May contain an error or the result of an
+ *   action.
+ */
+export function send<T> (res: Response, status: number, response: IResponseError | IResponseResult<T>) {
+	res.status(status).send(response);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3414,9 +3414,13 @@ typedoc@^0.5.10:
     typedoc-default-themes "^0.4.2"
     typescript "2.2.2"
 
-typescript@2.2.2, typescript@^2.2.2:
+typescript@2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
+
+typescript@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
 
 uglify-js@^2.6:
   version "2.8.22"


### PR DESCRIPTION
Adds a convenience function `send` which types the response format and ensures that errors are sent in the right format, responses are sent in the right format, and errors+responses are not present simultaneously.