### PR TITLE
Allow nodes to concatenate other CatNodes

### DIFF
--- a/db/seeds/development/messages.js
+++ b/db/seeds/development/messages.js
@@ -62,4 +62,10 @@ const DATA = [
 		tag: 'message_count',
 		date_created: 1494500304806,
 	},
+	{
+		id: 'a8b77ae9-f0fd-4e3d-a126-22087b12186e',
+		title: 'Recursive message test',
+		body: 'This message is published to node A which is concatenated by node B which is concatenated by node A etc.',
+		date_created: 1494657341036,
+	},
 ];

--- a/db/seeds/development/node-cat.js
+++ b/db/seeds/development/node-cat.js
@@ -38,6 +38,12 @@ const DATA = [
 		output_node_id: 'cd431717-6c53-4af1-a25a-e80bf611b79f',
 	},
 	{
+		// Recursive node child
+		input_node_id: '0035a5dd-74dd-4e4f-a0b5-5e905f679595',
+		// Recursive node A
+		output_node_id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
+	},
+	{
 		// Recursive node A
 		input_node_id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
 		// Recursive node B

--- a/db/seeds/development/node-cat.js
+++ b/db/seeds/development/node-cat.js
@@ -37,4 +37,16 @@ const DATA = [
 		// 'Update message by tag' cat node
 		output_node_id: 'cd431717-6c53-4af1-a25a-e80bf611b79f',
 	},
+	{
+		// Recursive node A
+		input_node_id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
+		// Recursive node B
+		output_node_id: '57ebddd5-3660-482f-b524-bb388cfad17c',
+	},
+	{
+		// Recursive node B
+		input_node_id: '57ebddd5-3660-482f-b524-bb388cfad17c',
+		// Recursive node A
+		output_node_id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
+	},
 ];

--- a/db/seeds/development/node-messages.js
+++ b/db/seeds/development/node-messages.js
@@ -63,4 +63,12 @@ const DATA = [
 		// You have 3 unread messages
 		message_id: 'e6bc24df-5db3-4041-8f36-bfe9d1f1187b',
 	},
+	{
+		// Recursive node child
+		node_id: '0035a5dd-74dd-4e4f-a0b5-5e905f679595',
+		// Recursive message test
+		// This message is published to node A which is concatenated by node B
+		// which is concatenated by node A etc.
+		message_id: 'a8b77ae9-f0fd-4e3d-a126-22087b12186e',
+	},
 ];

--- a/db/seeds/development/nodes.js
+++ b/db/seeds/development/nodes.js
@@ -47,4 +47,14 @@ const DATA = [
 		id: 'cd431717-6c53-4af1-a25a-e80bf611b79f',
 		node_type: 2,
 	},
+	{
+		// Recursive node A
+		id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
+		node_type: 2,
+	},
+	{
+		// Recursive node B
+		id: '57ebddd5-3660-482f-b524-bb388cfad17c',
+		node_type: 2,
+	},
 ];

--- a/db/seeds/development/nodes.js
+++ b/db/seeds/development/nodes.js
@@ -48,6 +48,11 @@ const DATA = [
 		node_type: 2,
 	},
 	{
+		// Recursive node child
+		id: '0035a5dd-74dd-4e4f-a0b5-5e905f679595',
+		node_type: 1,
+	},
+	{
 		// Recursive node A
 		id: 'b24558da-4867-4b9a-a8fb-930a8fdb25eb',
 		node_type: 2,

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -105,3 +105,23 @@ export interface IActionCatMessages extends IAction {
 export function isCatMessagesAction (action: IAction): action is IActionCatMessages {
 	return action.type === 'CatMessages';
 }
+
+/**
+ * Find all the nodes that the given nodes concatenate. Recurses the node tree
+ * to find not just immediate nodes but all nodes.
+ */
+export interface IActionExpandNodes extends IAction {
+	type: 'ExpandNodes';
+
+	/**
+	 * The IDs of the nodes to expand.
+	 */
+	nodeIds: UUID[];
+}
+
+/**
+ * Type guard. `true` if the given action is of type [[IActionExpandNodes]].
+ */
+export function isExpandNodesAction (action: IAction): action is IActionExpandNodes {
+	return action.type === 'ExpandNodes';
+}

--- a/src/engine/cat-messages.ts
+++ b/src/engine/cat-messages.ts
@@ -8,16 +8,22 @@ import {
 	IMessage,
 } from '../message';
 
+import { executeExpandNodes } from './expand-nodes';
+
 /**
  * Fetches all messages that belong to nodes which are concatenated by the
  * CatNode IDs provided.
  */
 export async function executeCatMessages (action: IActionCatMessages): Promise<IMessage[]> {
+	const nodeIds = await executeExpandNodes({
+		type: 'ExpandNodes',
+		nodeIds: action.nodeIds,
+	});
 	// Query DB
 	const rows: IMessage[] = await db('message')
 		.join('node_messages', 'message.id', '=', 'node_messages.message_id')
 		.join('node_cat', 'node_cat.input_node_id', '=', 'node_messages.node_id')
-		.where('node_cat.output_node_id', 'in', action.nodeIds)
+		.where('node_cat.output_node_id', 'in', nodeIds)
 		.orderBy('message.date_created', 'desc')
 		.orderBy('message.timestamp', 'desc')
 		.groupByRaw('ifnull(message.tag, message.id)')

--- a/src/engine/expand-nodes.ts
+++ b/src/engine/expand-nodes.ts
@@ -8,6 +8,10 @@ import {
 	UUID,
 } from '../types';
 
+import {
+	INode,
+} from '../node';
+
 export async function executeExpandNodes (action: IActionExpandNodes): Promise<UUID[]> {
 	const result: UUID[] = [];
 	let parentNodeIds: UUID[] = action.nodeIds;
@@ -20,13 +24,13 @@ export async function executeExpandNodes (action: IActionExpandNodes): Promise<U
 			break;
 		}
 	}
-	return result;
+	return [...result, ...action.nodeIds];
 }
 
 export async function getChildNodeIds (parentIds: UUID[], blackListIds: UUID[] = []): Promise<UUID[]> {
-	const result: UUID[] = await db('node_cat')
-		.column('input_node_id')
+	const rows: Partial<INode>[] = await db('node_cat')
+		.column('input_node_id as id')
 		.where('output_node_id', 'in', parentIds)
-		.andWhereNot('output_node_id', 'in', blackListIds);
-	return result;
+		.andWhere('output_node_id', 'not in', blackListIds);
+	return rows.map((row) => row.id);
 }

--- a/src/engine/expand-nodes.ts
+++ b/src/engine/expand-nodes.ts
@@ -1,0 +1,13 @@
+import { db } from '../connection';
+
+import {
+	IActionExpandNodes,
+} from '../actions';
+
+import {
+	UUID,
+} from '../types';
+
+export async function executeExpandNodes (action: IActionExpandNodes): Promise<UUID[]> {
+	throw new Error('Not yet implemented');
+}

--- a/src/engine/expand-nodes.ts
+++ b/src/engine/expand-nodes.ts
@@ -9,5 +9,24 @@ import {
 } from '../types';
 
 export async function executeExpandNodes (action: IActionExpandNodes): Promise<UUID[]> {
-	throw new Error('Not yet implemented');
+	const result: UUID[] = [];
+	let parentNodeIds: UUID[] = action.nodeIds;
+	while (true) {
+		const ids = await getChildNodeIds(parentNodeIds, result);
+		if (ids.length > 0) {
+			result.push(...ids);
+			parentNodeIds = ids;
+		} else {
+			break;
+		}
+	}
+	return result;
+}
+
+export async function getChildNodeIds (parentIds: UUID[], blackListIds: UUID[] = []): Promise<UUID[]> {
+	const result: UUID[] = await db('node_cat')
+		.column('input_node_id')
+		.where('output_node_id', 'in', parentIds)
+		.andWhereNot('output_node_id', 'in', blackListIds);
+	return result;
 }

--- a/src/engine/expand-nodes.ts
+++ b/src/engine/expand-nodes.ts
@@ -12,6 +12,11 @@ import {
 	INode,
 } from '../node';
 
+/**
+ * For a given list of node IDs, will return all the nodes they concatenate and
+ * all the nodes _they_ concatenate etc. Also returns the input nodes because
+ * some of them may be ReadNodes, not CatNodes.
+ */
 export async function executeExpandNodes (action: IActionExpandNodes): Promise<UUID[]> {
 	const result: UUID[] = [];
 	let parentNodeIds: UUID[] = action.nodeIds;
@@ -27,6 +32,11 @@ export async function executeExpandNodes (action: IActionExpandNodes): Promise<U
 	return [...result, ...action.nodeIds];
 }
 
+/**
+ * For a cat node will return the IDs of all the child nodes it concatenates.
+ * @param parentIds List of cat node IDs
+ * @param blackListIds Optional list of IDs to exclude from search
+ */
 export async function getChildNodeIds (parentIds: UUID[], blackListIds: UUID[] = []): Promise<UUID[]> {
 	const rows: Partial<INode>[] = await db('node_cat')
 		.column('input_node_id as id')

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -10,6 +10,8 @@ import {
 	isGetNodesAction,
 	IActionCatMessages,
 	isCatMessagesAction,
+	IActionExpandNodes,
+	isExpandNodesAction,
 } from '../actions';
 
 import {
@@ -20,15 +22,21 @@ import {
 	IMessage,
 } from '../message';
 
+import {
+	UUID,
+} from '../types';
+
 import { executeCreateNode } from './create-node';
 import { executeCreateMessage } from './create-message';
 import { executeGetNodes } from './get-nodes';
 import { executeCatMessages } from './cat-messages';
+import { executeExpandNodes } from './expand-nodes';
 
 export async function execute (action: IActionCreateNode): Promise<INode>;
 export async function execute (action: IActionCreateMessage): Promise<IMessage>;
 export async function execute (action: IActionGetNodes): Promise<INode[]>;
 export async function execute (action: IActionCatMessages): Promise<IMessage[]>;
+export async function execute (action: IActionExpandNodes): Promise<UUID[]>;
 export async function execute (action: IAction): Promise<any> {
 	if (isCreateNodeAction(action)) {
 		return executeCreateNode(action);
@@ -38,6 +46,8 @@ export async function execute (action: IAction): Promise<any> {
 		return executeGetNodes(action);
 	} else if (isCatMessagesAction(action)) {
 		return executeCatMessages(action);
+	} else if (isExpandNodesAction(action)) {
+		return executeExpandNodes(action);
 	} else {
 		throw new Error('Unrecognised action');
 	}

--- a/test/api/nodes.test.js
+++ b/test/api/nodes.test.js
@@ -236,6 +236,46 @@ test('Only the latest message with a particular tag is returned', async (t) => {
 	});
 });
 
+test('Can get messages from nodes that depend on each other', async (t) => {
+	t.plan(4);
+	const resA = await request(app).get('/b24558da-4867-4b9a-a8fb-930a8fdb25eb/messages');
+	t.is(resA.status, 200);
+	t.deepEqual(resA.body, {
+		"result": [
+			{
+				"id": "a8b77ae9-f0fd-4e3d-a126-22087b12186e",
+				"title": "Recursive message test",
+				"body": "This message is published to node A which is concatenated by node B which is concatenated by node A etc.",
+				"tag": null,
+				"icon": null,
+				"data": null,
+				"url": null,
+				"timestamp": null,
+				"dateCreated": 1494657341036,
+				"dateModified": null
+			}
+		]
+	});
+	const resB = await request(app).get('/57ebddd5-3660-482f-b524-bb388cfad17c/messages');
+	t.is(resB.status, 200);
+	t.deepEqual(resB.body, {
+		"result": [
+			{
+				"id": "a8b77ae9-f0fd-4e3d-a126-22087b12186e",
+				"title": "Recursive message test",
+				"body": "This message is published to node A which is concatenated by node B which is concatenated by node A etc.",
+				"tag": null,
+				"icon": null,
+				"data": null,
+				"url": null,
+				"timestamp": null,
+				"dateCreated": 1494657341036,
+				"dateModified": null
+			}
+		]
+	});
+});
+
 test('Cannot get messages from ReadNode', async (t) => {
 	t.plan(2);
 	const res = await request(app).get('/8c5c1e89-b523-4e2d-93c4-274f1c4baa6f/messages');


### PR DESCRIPTION
Currently CatNodes can only concatenate ReadNodes. This PR implements a recursive lookup to fetch an expanded list of node IDs for every message query.