### PR TITLE
Return list of concatenated nodes when querying CatNodes

### DIFF
--- a/db/seeds/development/nodes.js
+++ b/db/seeds/development/nodes.js
@@ -62,4 +62,9 @@ const DATA = [
 		id: '57ebddd5-3660-482f-b524-bb388cfad17c',
 		node_type: 2,
 	},
+	{
+		// CatNode with no inputs
+		id: '154d9c16-1c3a-4b1b-aa81-fda51132d573',
+		node_type: 2,
+	},
 ];

--- a/src/engine/get-nodes.ts
+++ b/src/engine/get-nodes.ts
@@ -15,6 +15,9 @@ import {
 	UUID,
 } from '../types';
 
+/**
+ * Get details about a given set of nodes.
+ */
 export async function executeGetNodes (action: IActionGetNodes): Promise<INode[]> {
 	const { nodeIds } = action;
 	const result = await db.transaction((tx) => Promise.all([
@@ -29,6 +32,9 @@ export async function executeGetNodes (action: IActionGetNodes): Promise<INode[]
 	return nodes;
 }
 
+/**
+ * Get information that is common to all nodes -- ID, type etc.
+ */
 export async function getNodeData (db: QueryBuilder, nodeIds: UUID[]): Promise<INode[]> {
 	const rows: INode[] = await db.table('node')
 		.join('node_types', 'node_types.id', 'node.node_type')
@@ -40,10 +46,33 @@ export async function getNodeData (db: QueryBuilder, nodeIds: UUID[]): Promise<I
 	return rows;
 }
 
+/**
+ * Maps input node IDs against a single output node ID.
+ */
 export interface NodeConcatMap {
+	/**
+	 * Key is an output node ID. Value is an array of input node IDs.
+	 *
+	 * The node with the ID in the key concatenates all the nodes with the IDs
+	 * in the value.
+	 *
+	 * @example
+	 *
+	 *     {
+	 *       "99e0c2cb-0d46-49aa-afe2-898f0f5af337": [
+	 *         "ccf90446-3267-4c59-9472-0f2043f3501c",
+	 *         "10eb2385-c8e5-4bea-be09-dc26cae237af",
+	 *         "e92d26e5-d10a-41c7-9439-dbc7d01161e4"
+	 *     }
+	 */
 	[outputId: string]: string[];
 }
 
+/**
+ * Returns a map of output node IDs (as keys) and the input node IDs they
+ * concatenate (as an array). Used to quickly look up all the nodes that a
+ * particular CatNode concatenates.
+ */
 export async function getNodeConcatMap (db: QueryBuilder, nodeIds: UUID[]): Promise<NodeConcatMap> {
 	const rows = await db.table('node_cat')
 		.whereIn('node_cat.output_node_id', nodeIds)

--- a/src/engine/get-nodes.ts
+++ b/src/engine/get-nodes.ts
@@ -53,8 +53,7 @@ export async function getNodeConcatMap (db: QueryBuilder, nodeIds: UUID[]): Prom
 		]);
 	// Map of inputs (as an array) that correspond to an output (index)
 	const map: NodeConcatMap = {};
-	for (const row of rows) {
-		const { inputId, outputId } = row;
+	for (const { inputId, outputId } of rows) {
 		const concatenates: UUID[] = map[outputId] || [];
 		concatenates.push(inputId);
 		map[outputId] = concatenates;

--- a/src/engine/get-nodes.ts
+++ b/src/engine/get-nodes.ts
@@ -1,4 +1,5 @@
 import { db } from '../connection';
+import { QueryBuilder } from 'knex';
 
 import {
 	IActionGetNodes,
@@ -6,15 +7,57 @@ import {
 
 import {
 	INode,
+	ICatNode,
+	isCatNode,
 } from '../node';
 
+import {
+	UUID,
+} from '../types';
+
 export async function executeGetNodes (action: IActionGetNodes): Promise<INode[]> {
-	const rows: INode[] = await db('node')
-		.join('node_types', 'node_types.id', '=', 'node.node_type')
-		.where('node.id', 'in', action.nodeIds)
+	const { nodeIds } = action;
+	const result = await db.transaction((tx) => Promise.all([
+		getNodeData(tx, action.nodeIds),
+		getNodeConcatMap(tx, action.nodeIds),
+	]));
+	const nodes: INode[] = result[0];
+	const concatMap: NodeConcatMap = result[1];
+	nodes.filter(isCatNode).forEach((node: ICatNode) => {
+		node.concatenates = concatMap[node.id];
+	});
+	return nodes;
+}
+
+export async function getNodeData (db: QueryBuilder, nodeIds: UUID[]): Promise<INode[]> {
+	const rows: INode[] = await db.table('node')
+		.join('node_types', 'node_types.id', 'node.node_type')
+		.whereIn('node.id', nodeIds)
 		.select([
 			'node.id',
 			'node_types.type_name as type',
 		]);
 	return rows;
+}
+
+export interface NodeConcatMap {
+	[outputId: string]: string[];
+}
+
+export async function getNodeConcatMap (db: QueryBuilder, nodeIds: UUID[]): Promise<NodeConcatMap> {
+	const rows = await db.table('node_cat')
+		.whereIn('node_cat.output_node_id', nodeIds)
+		.select([
+			'node_cat.output_node_id as outputId',
+			'node_cat.input_node_id as inputId',
+		]);
+	// Map of inputs (as an array) that correspond to an output (index)
+	const map: NodeConcatMap = {};
+	for (const row of rows) {
+		const { inputId, outputId } = row;
+		const concatenates: UUID[] = map[outputId] || [];
+		concatenates.push(inputId);
+		map[outputId] = concatenates;
+	}
+	return map;
 }

--- a/src/engine/get-nodes.ts
+++ b/src/engine/get-nodes.ts
@@ -27,7 +27,7 @@ export async function executeGetNodes (action: IActionGetNodes): Promise<INode[]
 	const nodes: INode[] = result[0];
 	const concatMap: NodeConcatMap = result[1];
 	nodes.filter(isCatNode).forEach((node: ICatNode) => {
-		node.concatenates = concatMap[node.id];
+		node.concatenates = concatMap[node.id] || null;
 	});
 	return nodes;
 }

--- a/test/api/nodes.test.js
+++ b/test/api/nodes.test.js
@@ -59,6 +59,21 @@ test('Can get details about multiple nodes', async (t) => {
 	});
 });
 
+test('CatNodes with no inputs have `concatenates` set to `null`', async (t) => {
+	t.plan(2);
+	const res = await request(app).get('/154d9c16-1c3a-4b1b-aa81-fda51132d573');
+	t.is(res.status, 200);
+	t.deepEqual(res.body, {
+		"result": [
+			{
+				"id": "154d9c16-1c3a-4b1b-aa81-fda51132d573",
+				"type": "CatNode",
+				"concatenates": null
+			}
+		]
+	});
+});
+
 test('Can get messages from CatNode', async (t) => {
 	t.plan(2);
 	const res = await request(app).get('/99e0c2cb-0d46-49aa-afe2-898f0f5af337/messages');

--- a/test/api/nodes.test.js
+++ b/test/api/nodes.test.js
@@ -18,7 +18,12 @@ test('Can get details about a node', async (t) => {
 		"result": [
 			{
 				"id": "99e0c2cb-0d46-49aa-afe2-898f0f5af337",
-				"type": "CatNode"
+				"type": "CatNode",
+				"concatenates": [
+					"ccf90446-3267-4c59-9472-0f2043f3501c",
+					"10eb2385-c8e5-4bea-be09-dc26cae237af",
+					"e92d26e5-d10a-41c7-9439-dbc7d01161e4"
+				]
 			}
 		]
 	});
@@ -32,11 +37,19 @@ test('Can get details about multiple nodes', async (t) => {
 		"result": [
 			{
 				"id": "99e0c2cb-0d46-49aa-afe2-898f0f5af337",
-				"type": "CatNode"
+				"type": "CatNode",
+				"concatenates": [
+					"ccf90446-3267-4c59-9472-0f2043f3501c",
+					"10eb2385-c8e5-4bea-be09-dc26cae237af",
+					"e92d26e5-d10a-41c7-9439-dbc7d01161e4"
+				]
 			},
 			{
 				"id": "afa0319a-9391-4c27-a7fe-e50f226ce735",
-				"type": "CatNode"
+				"type": "CatNode",
+				"concatenates": [
+					"8c5c1e89-b523-4e2d-93c4-274f1c4baa6f"
+				]
 			},
 			{
 				"id": "e92d26e5-d10a-41c7-9439-dbc7d01161e4",


### PR DESCRIPTION
Closes #10 

Querying a CatNode now returns a payload that looks like this:

```json
{
	"result": [
		{
			"id": "99e0c2cb-0d46-49aa-afe2-898f0f5af337",
			"type": "CatNode",
			"concatenates": [
				"ccf90446-3267-4c59-9472-0f2043f3501c",
				"10eb2385-c8e5-4bea-be09-dc26cae237af",
				"e92d26e5-d10a-41c7-9439-dbc7d01161e4"
			]
		}
	]
}
```